### PR TITLE
Set Reply-To in addition to From

### DIFF
--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -78,6 +78,7 @@ class SimpleContactForm_IndexController extends Omeka_Controller_AbstractActionC
             $mail = new Zend_Mail('UTF-8');
             $mail->setBodyText(get_option('simple_contact_form_admin_notification_email_message_header') . "\n\n" . $formMessage);
             $mail->setFrom($formEmail, $formName);
+            $mail->setReplyTo($formEmail, $formName);
             $mail->addTo($forwardToEmail);
             $mail->setSubject(get_option('site_title') . ' - ' . get_option('simple_contact_form_admin_notification_email_subject'));
             $mail->send();
@@ -89,6 +90,7 @@ class SimpleContactForm_IndexController extends Omeka_Controller_AbstractActionC
             $mail = new Zend_Mail('UTF-8');
             $mail->setBodyText(get_option('simple_contact_form_user_notification_email_message_header') . "\n\n" . $formMessage);
             $mail->setFrom($replyToEmail);
+            $mail->setReplyTo($replyToEmail);
             $mail->addTo($formEmail, $formName);
             $mail->setSubject(get_option('site_title') . ' - ' . get_option('simple_contact_form_user_notification_email_subject'));
             $mail->send();


### PR DESCRIPTION
Using GMail SMTP mangles the From header. Reply-To is passed through to the recipient and setting it to the same address as the from header shouldn't cause any issues for other smtp setups (that I am aware of).